### PR TITLE
Update YangAbstractDataContainer.java

### DIFF
--- a/yangkit-data-impl/src/main/java/org/yangcentral/yangkit/data/impl/model/YangAbstractDataContainer.java
+++ b/yangkit-data-impl/src/main/java/org/yangcentral/yangkit/data/impl/model/YangAbstractDataContainer.java
@@ -321,7 +321,7 @@ public class YangAbstractDataContainer implements YangDataContainer {
 
     private ValidatorResult checkMandatory(SchemaNode schemaNode, List<YangData<?>> matchedData) {
         ValidatorResultBuilder validatorResultBuilder = new ValidatorResultBuilder();
-        if(schemaNode.isMandatory()){
+        if(schemaNode.isMandatory() && schemaNode.isActive() && schemaNode.isConfig()){
             if(matchedData.isEmpty()){
                 //if have when condition, valuate this when condition,if true, report error
                 YangData<?> dummyNode = new YangDataBuilder().getYangData(schemaNode,null);


### PR DESCRIPTION
The missing mandatory schema node error is incorrectly reported on tailored nodes and ineffective nodes.